### PR TITLE
[MCC-000000] fail if job queue fails

### DIFF
--- a/test/fossa_travis_tests.sh
+++ b/test/fossa_travis_tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+install_fossa__adds_fossa_cmd()
+{
+  echo "Test install_fossa__adds_fossa_cmd..."
+  export TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-`pwd`}
+  echo "Info: TRAVIS_BUILD_DIR is $TRAVIS_BUILD_DIR"
+
+  ../travis_ci/fossa_install.sh &> /dev/null 
+  ret=$?
+  echo "Info: fossa_install.sh exit code is $ret"
+  if [ $ret -ne 0 ]; then
+    echo 'Error: fossa_install.sh failed' >&2
+    return 1
+  fi
+
+  if ! [ -x "$(command -v './fossa')" ]; then
+    echo 'Error: fossa not installed' >&2
+    return 1
+  fi
+  echo 'PASSED'
+  return 0
+}
+
+run_fossa__fails_if_api_key_missing()
+{
+  echo "Test run_fossa__fails_if_api_key_missing..."
+
+  ../travis_ci/fossa_run.sh &> /dev/null
+  ret=$?
+  echo "Info: fossa_run.sh exit code is $ret"
+  if [ $ret -eq 0 ]; then
+    echo 'Error: fossa_run.sh succeeded but should have failed' >&2
+    return 1
+  fi
+
+  echo 'PASSED'
+  return 0
+}
+
+TESTS_PASS=0
+# add new tests here and follow pattern to exit with error if any fail
+install_fossa__adds_fossa_cmd || TESTS_PASS=$?
+run_fossa__fails_if_api_key_missing || TESTS_PASS=$?
+exit $TESTS_PASS

--- a/travis_ci/fossa_install.sh
+++ b/travis_ci/fossa_install.sh
@@ -5,6 +5,12 @@ install_fossa()
   # Install FOSSA CLI via FOSSA provided Install Script; CLI is installed to Build Folder to avoid needing sudo access
   echo "Installing FOSSA CLI..."
   curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b $TRAVIS_BUILD_DIR
+  
+  if ( $? -ne 0 ); then
+    echo "FOSSA CLI Install Failed :("
+    exit 1 
+  fi
+
   echo "FOSSA CLI Installed Successfully!"
 }
 
@@ -13,7 +19,6 @@ if [ -z $CI_NODE_INDEX ]; then
   # No Build Node Index provided; assume single thread (non-parallel) build, so install CLI
   echo "Single Node Execution Detected..."
   install_fossa
-
 else
   # Build Node Index provided; assume multi-thread (parallel) build; default to Node Index 0
   echo "Parallel Node Execution Detected..."
@@ -27,3 +32,4 @@ else
     echo "Current Node Index ($CI_NODE_INDEX) is not FOSSA Execution Node ($FOSSA_NODE_INDEX).  Skipping FOSSA Installation!"
   fi
 fi
+exit 0

--- a/travis_ci/fossa_run.sh
+++ b/travis_ci/fossa_run.sh
@@ -4,9 +4,13 @@ run_fossa()
 {
   echo "Queuing FOSSA Checks..."
   ./fossa
-  echo "FOSSA Checks Queued Successfully!"
-  
-  fail_build_check
+  if ($? -eq 0)
+    echo "FOSSA Checks Queued Successfully!"  
+    fail_build_check
+  else
+    echo "FOSSA Checks Failed to Queue :("
+    exit 1
+  fi
 }
 
 fail_build_check()
@@ -48,3 +52,4 @@ else
     echo "Current Node Index ($CI_NODE_INDEX) is not FOSSA Execution Node ($FOSSA_NODE_INDEX).  Skipping FOSSA Execution!"
   fi
 fi
+exit 0


### PR DESCRIPTION
- this prevents builds from continuing if, for example, the API key is missing

While installing FOSSA checking on [dictionary service](https://github.com/mdsol/dictionary-service) we discovered that if the API Key is not accessible and the environment is set up to fail builds that do not pass the FOSSA checks then the build will enter an infinite loop and, after 10 minutes, *return success*. See [this travis build output for an example](https://travis-ci.com/mdsol/dictionary-service/jobs/192597554#L304). Obviously this is undesired behavior so this PR fixes that.

Note, this does _not_ respect the `FOSSA_FAIL_BUILD` environment setting and will fail an invalid build regardless if the checks cannot be queued. This behavior was asked for by @Jman420 

> Daniel King [3:32 PM]
> requirements question: Do you want to fail the build if the API key is missing regardless of the value of `FOSSA_FAIL_BUILD` or should that value always be respected? (edited) 
>
> Justin Giannone [3:33 PM]
> lets fail if API key is missing regardless

Note also, this does not solve the issue of an infinite loop terminating in a successful error code (that should be taken up in a separate PR).