### PR TITLE
improve the Travis CI instructions

### DIFF
--- a/travis_ci/SETUP.md
+++ b/travis_ci/SETUP.md
@@ -1,38 +1,43 @@
 # Travis CI FOSSA Setup Instructions
 
 ## Necessary Steps
-  - Follow instructions to [Obtain a FOSSA API Key](/OBTAINING_API_KEY.md)
-  - Request a Github Admin (see #github-admins Slack Channel) to add the FOSSA API Key to your Travis Project
-    * __*NOTE*__ : Make sure to send the API Key only via Encrypted Email
-  - Open the Project's '.travis.yml' file for editing on your Local Machine
-  - Add the following line to the Travis YML 'install' stage exactly as it appears below :  
+
+- Follow the instructions to [obtain a FOSSA API key](/OBTAINING_API_KEY.md)
+- Request a Github Admin (see #github-admins Slack Channel) to add the FOSSA API key to your Travis project
+  - __*NOTE*__: Make sure to send the API key only via Encrypted Email
+- Edit the Travis YML (`.travis.yml`) exactly as it appears below:
+  - Add to the `install` section:
   ```
-  - |- 
-    curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh | bash -s -- -b $TRAVIS_BUILD_DIR
+  - >
+    curl -H 'Cache-Control: no-cache'
+    https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh |
+    bash -s -- -b $TRAVIS_BUILD_DIR
   ```
-  - Add the following line to the Travis YML 'script' stage exactly as it appears below :  
+  - Add to the `script` section:
   ```
-  - |- 
-    curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_run.sh | bash -s -- -b $TRAVIS_BUILD_DIR
+  - >
+    curl -H 'Cache-Control: no-cache'
+    https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_run.sh |
+    bash -s -- -b $TRAVIS_BUILD_DIR
   ```
-  - Follow any necessary [Optional Steps](#optional-steps) found below
-  - Follow necessary steps to [Setup FOSSA CLI](/FOSSA_CLI_SETUP.md)
-  - Commit & Push changes to GitHub
-  - Open a Pull Request against a TravisCI Monitored Branch
-  - Check TravisCI Project Pipeline for errors or failures
-  - Merge the Pull Request when satisfied with output
+- Follow any of the [optional steps](#optional-steps) found below
+- Follow the necessary steps to [setup FOSSA CLI](/FOSSA_CLI_SETUP.md)
+- Commit & push changes to GitHub
+- Open a pull request against a Travis CI monitored branch
+- Check the Travis CI project run for errors or failures
+- Merge the pull request when satisfied with the output
 
 ## Optional Steps
 
 ### Add FOSSA API Key to Travis Project
-  - Log into TravisCI and open the appropriate Project
-  - Click 'More Options' -> 'Settings' on the right of the Project Page
-  - Add an Environment Variable named 'FOSSA_API_KEY', set it's value to the provided API Key and set 'Display value in log' to Disabled
+- Log into Travis CI and open the appropriate project
+- Click "More Options" → "Settings" on the right side of the project page
+- Add an environment variable named `FOSSA_API_KEY`, set its value to the provided API key, and set "Display value in log" to "Disabled"
 
 ### Parallelized Builds
-  - Add an Environment Variable to the Travis YML called 'FOSSA_NODE_INDEX' and set its value to the Node Index which should execute the tasks  
-**_Note_** : Scripts expect the Executing Node Index to be stored in an Environment Variable called 'CI_NODE_INDEX'.  If this Environment Variable does not exist then the scripts will assume that no Parallelization is taking place and the tasks will be executed on every node.  This is not recommended and can muddy the results of the evaluation.
+- Add an environment variable to the Travis YML named `FOSSA_NODE_INDEX` and set its value to the node index which should execute the tasks.
+  - __*Note*__: Scripts expect the executing node index to be stored in an environment variable called `CI_NODE_INDEX`. If this environment variable does not exist then the scripts will assume that no parallelization is taking place and the tasks will be executed on every node. This is not recommended and can muddy the results of the evaluation.
 
 ### Failing Builds on Policy Violations
-  - Add an Environment Variable to the Travis YML called 'FOSSA_FAIL_BUILD' and set its value to 'true'  
-**_Note_** : This functionalily is optional at this time (Nov 2018), but will be made manditory through script updates in the future.  This toggle is a courtesy for teams which want to get a head start on these requirements.
+- Add an environment variable to the Travis YML named `FOSSA_FAIL_BUILD` and set its value to `true`.
+  - __*Note*__: This functionalily is optional at this time (Nov 2018), but will be made mandatory through script updates in the future. This toggle is a courtesy for teams which want to get a head start on these requirements.


### PR DESCRIPTION
I keep commenting over and over again on PRs that the currently provided yml code can be improved by using yml's `>` operator, which interprets new lines as spaces. 

Demo:
```yml
# fossa.yml
- |-
  curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh | bash -s -- -b $TRAVIS_BUILD_DIR
- >
  curl -H 'Cache-Control: no-cache'
  https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh |
  bash -s -- -b $TRAVIS_BUILD_DIR
```
```sh
ruby -e 'require "yaml"; puts YAML.load_file("fossa.yml")'

curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh | bash -s -- -b $TRAVIS_BUILD_DIR
curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh | bash -s -- -b $TRAVIS_BUILD_DIR
```

@Jman420 @mdsol/architecture-enablement 