### PR TITLE
chomp trailing newline character in fossa cmd

### DIFF
--- a/travis_ci/SETUP.md
+++ b/travis_ci/SETUP.md
@@ -8,14 +8,14 @@
 - Edit the Travis YML (`.travis.yml`) exactly as it appears below:
   - Add to the `install` section:
   ```
-  - >
+  - >-
     curl -H 'Cache-Control: no-cache'
     https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_install.sh |
     bash -s -- -b $TRAVIS_BUILD_DIR
   ```
   - Add to the `script` section:
   ```
-  - >
+  - >-
     curl -H 'Cache-Control: no-cache'
     https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_run.sh |
     bash -s -- -b $TRAVIS_BUILD_DIR


### PR DESCRIPTION
in PR #20 I forgot to add a hyphen to the yaml indicator with the consequence the command would retain a trailing newline character.
functionally-wise it's identical, it just prevents travis from printing the command on 2 lines, e.g.
```
The command "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/mdsol/fossa_ci_scripts/master/travis_ci/fossa_run.sh | bash -s -- -b $TRAVIS_BUILD_DIR
" exited with 0.
```