### PR TITLE
Add the ability to run FOSSA as a shared GitHub action

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ This repository contains Scripts for use with integrating FOSSA into CI Pipeline
   - [Accessing FOSSA](ACCESSING_FOSSA.md)
   - [Configuring TravisCI](travis_ci/SETUP.md)
   - [Configuring Jenkins](jenkins/SETUP.md)
+  - [Configuring Github Actions](github_actions/SETUP.md)
   - Configuring GoCD - Coming Soon

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,7 @@
+name: 'FOSSA'
+description: 'Run FOSSA dependency analysis and upload'
+runs:
+  using: "composite"
+  steps: 
+    - run: bash ${{ github.action_path }}/github_actions/run.sh
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,3 @@ runs:
   steps: 
     - run: bash ${{ github.action_path }}/github_actions/run.sh
       shell: bash
-      env:
-        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/action.yml
+++ b/action.yml
@@ -5,3 +5,5 @@ runs:
   steps: 
     - run: bash ${{ github.action_path }}/github_actions/run.sh
       shell: bash
+      env:
+        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}

--- a/github_actions/SETUP.md
+++ b/github_actions/SETUP.md
@@ -1,0 +1,42 @@
+# Travis CI FOSSA Setup Instructions
+
+## Necessary Steps
+
+- Add a `/.github/workflows/fossa.yml` with the following contents (or update an existing workflow file to include the `steps`):
+
+```
+name: Dependency License Scanning
+
+on:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Test for License Violations
+      uses: mdsol/fossa_ci_scripts@master
+      env:
+        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+```
+
+Note that `secrets.FOSSA_API_KEY` is configured as an organization secret, and should be accessible across all mdsol repos.
+
+## Optional Steps
+
+### Failing Builds on Policy Violations
+- By default, the action is designed to fail the build if there are policy violations. In order to scan without failing the build, add an `env` variable to the workflow YML named `FOSSA_FAIL_BUILD` and set its value to `false`. For example:
+```
+    - name: Test for License Violations (without failing the build)
+      uses: mdsol/fossa_ci_scripts@master
+      env:
+        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        FOSSA_FAIL_BUILD: false
+```

--- a/github_actions/run.sh
+++ b/github_actions/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+install_fossa()
+{
+  echo "Installing FOSSA CLI"
+  curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s
+  ret=$?
+  if [ $ret -ne 0 ]; then
+    echo 'Error: FOSSA install failed' >&2
+    exit 1
+  fi
+}
+
+run_fossa()
+{
+  echo "Analyzing and testing licenses..."
+  fossa init
+  fossa analyze
+  result=$?
+  if [ "${FOSSA_FAIL_BUILD:-true}" == "true" ]; then
+    result=$(fossa test)
+    echo "fossa test result: $result"
+  fi
+  exit $result
+}
+
+install_fossa && run_fossa


### PR DESCRIPTION
## Feature

This PR adds an action.yml that allows any repo to integrate FOSSA validation into their pipeline via Github Actions.

## Testing

Using the yaml described in SETUP.md, the DictionaryParser repo and was able to successfully scan and upload the results to FOSSA. Check out the run [here](https://github.com/mdsol/DictionaryParser/actions/runs/271033514).