### PR TITLE
Disable build failure on Submission Failure due to stability issues

### DIFF
--- a/jenkins/fossa_run.sh
+++ b/jenkins/fossa_run.sh
@@ -8,7 +8,10 @@ run_fossa()
     fail_build_check
   else
     echo "FOSSA Checks Failed to Queue :("
-    exit 1
+    
+    # Build Failure Disabled due to FOSSA Stability issue around token permission (1/21/2021); re-enable once stability restored
+    # exit 1
+    exit 0
   fi
 }
 

--- a/travis_ci/fossa_run.sh
+++ b/travis_ci/fossa_run.sh
@@ -8,7 +8,10 @@ run_fossa()
     fail_build_check
   else
     echo "FOSSA Checks Failed to Queue :("
-    exit 1
+    
+    # Build Failure Disabled due to FOSSA Stability issue around token permission (1/21/2021); re-enable once stability restored
+    # exit 1
+    exit 0
   fi
 }
 


### PR DESCRIPTION
Stability issues on FOSSA Platform are causing intermittent permission failures from FOSSA CLI.  Disabling build failure on permission failures to unblock teams.

Change to be reverted once stability is restored