### PR TITLE
Return correct exit codes.

### DIFF
--- a/github_actions/run.sh
+++ b/github_actions/run.sh
@@ -18,7 +18,8 @@ run_fossa()
   fossa analyze
   result=$?
   if [ "${FOSSA_FAIL_BUILD:-true}" == "true" ]; then
-    result=$(fossa test)
+    fossa test
+    result=$?
     echo "fossa test result: $result"
   fi
   exit $result

--- a/jenkins/fossa_debug.sh
+++ b/jenkins/fossa_debug.sh
@@ -25,7 +25,8 @@ fail_build_check()
   if [ "$FOSSA_FAIL_BUILD_TOGGLE" == "true" ]; then
     # Return FOSSA CLI Exit Code for Build Failures
     echo "FOSSA Fail Build Flag Enabled.  Checking for Policy Violations..."
-    export FOSSA_EXIT_CODE=$(./fossa test --debug)
+    ./fossa test --debug
+    export FOSSA_EXIT_CODE=$?
     echo "FOSSA Policy Violations check returned : $FOSSA_EXIT_CODE (non-zero codes are failures)"
     exit $FOSSA_EXIT_CODE
   else

--- a/jenkins/fossa_run.sh
+++ b/jenkins/fossa_run.sh
@@ -25,7 +25,8 @@ fail_build_check()
   if [ "$FOSSA_FAIL_BUILD_TOGGLE" == "true" ]; then
     # Return FOSSA CLI Exit Code for Build Failures
     echo "FOSSA Fail Build Flag Enabled.  Checking for Policy Violations..."
-    export FOSSA_EXIT_CODE=$(./fossa test)
+    ./fossa test
+    export FOSSA_EXIT_CODE=$?
     echo "FOSSA Policy Violations check returned : $FOSSA_EXIT_CODE (non-zero codes are failures)"
     exit $FOSSA_EXIT_CODE
   else

--- a/travis_ci/fossa_debug.sh
+++ b/travis_ci/fossa_debug.sh
@@ -25,7 +25,8 @@ fail_build_check()
   if [ "$FOSSA_FAIL_BUILD_TOGGLE" == "true" ]; then
     # Return FOSSA CLI Exit Code for Build Failures
     echo "FOSSA Fail Build Flag Enabled.  Checking for Policy Violations..."
-    export FOSSA_EXIT_CODE=$(./fossa test --debug)
+    ./fossa test --debug
+    export FOSSA_EXIT_CODE=$?
     echo "FOSSA Policy Violations check returned : $FOSSA_EXIT_CODE (non-zero codes are failures)"
     exit $FOSSA_EXIT_CODE
   else

--- a/travis_ci/fossa_run.sh
+++ b/travis_ci/fossa_run.sh
@@ -25,7 +25,8 @@ fail_build_check()
   if [ "$FOSSA_FAIL_BUILD_TOGGLE" == "true" ]; then
     # Return FOSSA CLI Exit Code for Build Failures
     echo "FOSSA Fail Build Flag Enabled.  Checking for Policy Violations..."
-    export FOSSA_EXIT_CODE=$(./fossa test)
+    ./fossa test
+    export FOSSA_EXIT_CODE=$?
     echo "FOSSA Policy Violations check returned : $FOSSA_EXIT_CODE (non-zero codes are failures)"
     exit $FOSSA_EXIT_CODE
   else


### PR DESCRIPTION
These changes resolve a bash error when trying to exit with a string value.

Fossa commands were run and their output was stored in a variable. That
variable was then passed to exit. Exit expects a numeric value between 0
and 255 and not a string so it gave this error:

exit: Test: numeric argument required

This change stores the return code from the fossa run in the variable that
later passed to exit.