### PR TITLE
[HouseKeeping]Allow custom bin dir

### DIFF
--- a/github_actions/SETUP.md
+++ b/github_actions/SETUP.md
@@ -24,10 +24,11 @@ jobs:
       uses: mdsol/fossa_ci_scripts@main
       env:
         FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-
+        FOSSA_BIN_DIR: "/usr/local/bin"
 ```
 
 Note that `secrets.FOSSA_API_KEY` is configured as an organization secret, and should be accessible across all mdsol repos.
+Fossa scripts will be installed under FOSSA_BIN_DIR, default value is `/usr/local/bin`. If using github-hosted agents, please change this directory to avoid permission issues.
 
 ## Optional Steps
 

--- a/github_actions/run.sh
+++ b/github_actions/run.sh
@@ -15,6 +15,8 @@ install_fossa()
 run_fossa()
 {
   echo "Analyzing and testing licenses..."
+  FOSSA_BIN_DIR="${FOSSA_BIN_DIR:=/usr/local/bin}"
+  export PATH=$PATH:$FOSSA_BIN_DIR
   fossa init
   fossa analyze
   result=$?

--- a/github_actions/run.sh
+++ b/github_actions/run.sh
@@ -3,7 +3,8 @@
 install_fossa()
 {
   echo "Installing FOSSA CLI"
-  curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s
+  FOSSA_BIN_DIR="${FOSSA_BIN_DIR:=/usr/local/bin}"
+  curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash -s -- -b $FOSSA_BIN_DIR
   ret=$?
   if [ $ret -ne 0 ]; then
     echo 'Error: FOSSA install failed' >&2


### PR DESCRIPTION
Allow custom bin dir. This is to avoid the permission issue when using github-hosted agents:
```
install: cannot change permissions of '/usr/local/bin': Operation not permitted
Error: FOSSA install failed
Error: Process completed with exit code 1.
```